### PR TITLE
Wrap GTM events in Suspense

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from 'next/font/google'
 import './globals.css'
 import StructuredData from '@/components/SEO/StructuredData'
 import Script from 'next/script'
+import { Suspense } from 'react'
 // (Opcional recomendado) escucha de pageviews en SPA
 import GTMEvents from '@/components/analytics/GTMEvents'
 
@@ -138,7 +139,9 @@ export default function RootLayout({
           }}
         />
         {/* Pageviews en navegaciones SPA */}
-        <GTMEvents />
+        <Suspense fallback={null}>
+          <GTMEvents />
+        </Suspense>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- import Suspense and wrap GTMEvents with a null fallback to prevent build errors from useSearchParams

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter`: https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fc8d5f148333a637be2ee3c5a155