### PR TITLE
refactor: move theme color to viewport

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -96,7 +96,10 @@ export const metadata: Metadata = {
   verification: {
     google: 'tu-codigo-de-verificacion',
   },
-  themeColor: '#3AAA35', // ← añadido
+}
+
+export const viewport = {
+  themeColor: '#3AAA35',
 }
 
 // TU ID específico de Google Tag Manager


### PR DESCRIPTION
## Summary
- remove themeColor from metadata in `layout.tsx`
- export viewport with theme color per Next.js API

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c1fc8c62c8833381a443bd61024f20