### PR TITLE
Wrap GTM events in suspense

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from 'next/font/google'
 import './globals.css'
 import StructuredData from '@/components/SEO/StructuredData'
 import Script from 'next/script'
+import { Suspense } from 'react'
 // (Opcional recomendado) escucha de pageviews en SPA
 import GTMEvents from '@/components/analytics/GTMEvents'
 
@@ -138,7 +139,9 @@ export default function RootLayout({
           }}
         />
         {/* Pageviews en navegaciones SPA */}
-        <GTMEvents />
+        <Suspense fallback={null}>
+          <GTMEvents />
+        </Suspense>
         {children}
       </body>
     </html>


### PR DESCRIPTION
## Summary
- wrap GTMEvents in a Suspense boundary to allow useSearchParams on 404 and other pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c203db647083339b751956a95b304b