### PR TITLE
Agregar botones de contacto alterno en página de alfombras

### DIFF
--- a/src/app/servicios/alfombras/AlfombrasClient.tsx
+++ b/src/app/servicios/alfombras/AlfombrasClient.tsx
@@ -118,8 +118,10 @@ export default function AlfombrasClient() {
   // URLs de WhatsApp correctas y codificadas
   const precioMsg = `Hola, quiero una cotización exacta para lavado de alfombras en ${ciudad}. ¿Me pueden ayudar?`
   const precioHref = `https://wa.me/573128052720?text=${encodeURIComponent(precioMsg)}`
+  const precioHrefSecundario = `https://wa.me/573209210866?text=${encodeURIComponent(precioMsg)}`
   const ofertaMsg = `Quiero aprovechar la oferta del ${descuento}% en lavado de alfombras`
   const ofertaHref = `https://wa.me/573128052720?text=${encodeURIComponent(ofertaMsg)}`
+  const ofertaHrefSecundario = `https://wa.me/573209210866?text=${encodeURIComponent(ofertaMsg)}`
 
   return (
     <>
@@ -532,7 +534,7 @@ export default function AlfombrasClient() {
               </div>
             </div>
 
-            <div className="text-center">
+            <div className="text-center space-y-3">
               <p className="text-gray-600 mb-4">
                 * Precio referencial para alfombra de 2x3 metros. Cotización exacta según tamaño y estado.
               </p>
@@ -543,6 +545,14 @@ export default function AlfombrasClient() {
                 className="inline-block bg-gradient-to-r from-blue-600 to-blue-700 text-white px-8 py-3 rounded-full font-semibold hover:from-blue-700 hover:to-blue-800 transform hover:scale-105 transition-all duration-300 shadow-lg"
               >
                 Obtener Precio Exacto
+              </a>
+              <a
+                href={precioHrefSecundario}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-block border-2 border-blue-600 text-blue-700 px-8 py-3 rounded-full font-semibold hover:bg-blue-50 transform hover:scale-105 transition-all duration-300"
+              >
+                Contacto alterno: 320 921 0866
               </a>
             </div>
           </div>
@@ -690,17 +700,27 @@ export default function AlfombrasClient() {
             </p>
           </div>
 
-          <a
-            href={ofertaHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center bg-green-500 text-white px-10 py-5 rounded-full font-bold text-xl hover:bg-green-600 transform hover:scale-105 transition-all duration-300 shadow-2xl animate-pulse"
-          >
-            <svg className="w-8 h-8 mr-3" fill="currentColor" viewBox="0 0 24 24">
-              <path d="M12.004 2c-5.46 0-9.89 4.43-9.89 9.89 0 1.75.46 3.39 1.24 4.82L2.004 22l5.41-1.34A9.868 9.868 0 0012.004 22c5.46 0 9.89-4.43 9.89-9.89 0-2.65-1.03-5.14-2.9-7.01A9.818 9.818 0 0012.004 2zm0 1.67c4.54 0 8.22 3.68 8.22 8.22 0 4.54-3.68 8.22-8.22 8.22-1.37 0-2.68-.34-3.82-.97l-.27-.15-2.83.7.72-2.77-.17-.29a8.174 8.174 0 01-1.08-4.02c0-4.54 3.68-8.22 8.22-8.22h.23zm-2.71 4.25c-.17 0-.44.06-.67.31-.23.26-.87.85-.87 2.07 0 1.22.89 2.39 1.01 2.56.12.17 1.75 2.67 4.23 3.74 2.05.88 2.48.71 2.93.66.45-.05 1.45-.59 1.65-1.16.2-.57.2-1.05.14-1.16-.06-.11-.23-.17-.48-.29-.25-.12-1.47-.73-1.7-.81-.23-.08-.4-.12-.56.12-.17.25-.64.81-.78.97-.14.17-.29.19-.54.06-.25-.12-1.05-.39-1.99-1.23-.74-.66-1.23-1.47-1.38-1.72-.14-.25-.02-.38.11-.51.12-.11.25-.29.37-.44.12-.14.17-.25.25-.42.08-.17.04-.31-.02-.44-.06-.12-.56-1.35-.77-1.85-.2-.48-.41-.42-.56-.43-.14 0-.31-.02-.48-.02z" />
-            </svg>
-            Reclamar Oferta Ahora
-          </a>
+          <div className="flex flex-col items-center gap-3">
+            <a
+              href={ofertaHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center bg-green-500 text-white px-10 py-5 rounded-full font-bold text-xl hover:bg-green-600 transform hover:scale-105 transition-all duration-300 shadow-2xl animate-pulse"
+            >
+              <svg className="w-8 h-8 mr-3" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M12.004 2c-5.46 0-9.89 4.43-9.89 9.89 0 1.75.46 3.39 1.24 4.82L2.004 22l5.41-1.34A9.868 9.868 0 0012.004 22c5.46 0 9.89-4.43 9.89-9.89 0-2.65-1.03-5.14-2.9-7.01A9.818 9.818 0 0012.004 2zm0 1.67c4.54 0 8.22 3.68 8.22 8.22 0 4.54-3.68 8.22-8.22 8.22-1.37 0-2.68-.34-3.82-.97l-.27-.15-2.83.7.72-2.77-.17-.29a8.174 8.174 0 01-1.08-4.02c0-4.54 3.68-8.22 8.22-8.22h.23zm-2.71 4.25c-.17 0-.44.06-.67.31-.23.26-.87.85-.87 2.07 0 1.22.89 2.39 1.01 2.56.12.17 1.75 2.67 4.23 3.74 2.05.88 2.48.71 2.93.66.45-.05 1.45-.59 1.65-1.16.2-.57.2-1.05.14-1.16-.06-.11-.23-.17-.48-.29-.25-.12-1.47-.73-1.7-.81-.23-.08-.4-.12-.56.12-.17.25-.64.81-.78.97-.14.17-.29.19-.54.06-.25-.12-1.05-.39-1.99-1.23-.74-.66-1.23-1.47-1.38-1.72-.14-.25-.02-.38.11-.51.12-.11.25-.29.37-.44.12-.14.17-.25.25-.42.08-.17.04-.31-.02-.44-.06-.12-.56-1.35-.77-1.85-.2-.48-.41-.42-.56-.43-.14 0-.31-.02-.48-.02z" />
+              </svg>
+              Reclamar Oferta Ahora
+            </a>
+            <a
+              href={ofertaHrefSecundario}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center border-2 border-white text-white px-8 py-3 rounded-full font-semibold hover:bg-white/10 transform hover:scale-105 transition-all duration-300"
+            >
+              Contacto alterno: 320 921 0866
+            </a>
+          </div>
 
           <p className="mt-6 text-sm opacity-80">* Válido solo para nuevos clientes. Un uso por hogar. Aplica solo en {ciudad}.</p>
         </div>


### PR DESCRIPTION
### Motivation
- Añadir un número secundario de contacto WhatsApp (`3209210866`) en la landing `/servicios/alfombras` para ofrecer una vía alternativa de contacto sin eliminar ni modificar la funcionalidad existente.

### Description
- Se añadieron dos nuevas constantes de URL de WhatsApp: `precioHrefSecundario` y `ofertaHrefSecundario` en `src/app/servicios/alfombras/AlfombrasClient.tsx` que apuntan a `wa.me/573209210866` con los mismos mensajes que los enlaces principales.
- Se añadió un botón secundario "Contacto alterno: 320 921 0866" en la sección de precios junto al botón `Obtener Precio Exacto` sin eliminar el botón original.
- Se añadió un botón secundario idéntico en el CTA final junto al botón principal `Reclamar Oferta Ahora`, manteniendo ambos CTAs funcionales y con estilos coherentes.
- Los cambios fueron commiteados en el repositorio y el archivo modificado es `AlfombrasClient.tsx` (32 inserciones, 12 eliminaciones en el diff aplicado).

### Testing
- Ejecuté `npm run lint` y no arrojó errores ni warnings (✅ lint passed).
- Inicié el servidor de desarrollo (`next dev`) y la ruta `/servicios/alfombras` respondió correctamente; el servidor mostró advertencias relacionadas con la descarga de fuentes externas y mensajes preexistentes sobre `searchParams`, pero la página se desplegó y permitió la verificación visual (dev run terminó con warnings, no error crítico).
- Validación visual automatizada con Playwright que abrió `http://127.0.0.1:3000/servicios/alfombras` y generó la captura `artifacts/alfombras-secondary-contact.png` (✅ screenshot generado).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e5db0cbdc833389ef1dc7e533d79a)